### PR TITLE
Release 0.6.1: migrate CLI for post-parsedmarc-upgrade data repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.6.1 2026-04-23
+
+### Added
+
+- `dmarcmsp migrate` CLI group with one-shot data-repair commands for
+  existing OpenSearch indices after a parsedmarc upgrade:
+  - `migrate rename-asn-fields` renames `source_asn_{name,domain}` to
+    `source_as_{name,domain}` on historical docs.
+  - `migrate refill-enrichment` re-derives IP-based enrichment fields
+    (`source_country`, `source_name`, `source_type`, `source_as_name`,
+    `source_as_domain`) by invoking `parsedmarc.utils.get_ip_address_info`
+    inside the parsedmarc container, so historical data matches the
+    enrichment new docs receive. Configurable via `--fields`.
+  - `migrate refresh-index-fields` rebuilds each tenant's cached
+    index-pattern field list from the live OpenSearch mapping, picking
+    up newly added or renamed parsedmarc fields.
+  - `migrate all` runs all three in order.
+- `DashboardService.refresh_index_pattern_fields(tenant_name)` backing
+  the per-tenant field refresh.
+
 ## 0.6.0 2026-04-17
 
 ### Changed

--- a/dmarc_msp/cli/__init__.py
+++ b/dmarc_msp/cli/__init__.py
@@ -22,6 +22,7 @@ from dmarc_msp.cli.client import app as client_app  # noqa: E402
 from dmarc_msp.cli.client_user import app as client_user_app  # noqa: E402
 from dmarc_msp.cli.dashboard import app as dashboard_app  # noqa: E402
 from dmarc_msp.cli.domain import app as domain_app  # noqa: E402
+from dmarc_msp.cli.migrate import app as migrate_app  # noqa: E402
 from dmarc_msp.cli.parsedmarc import app as parsedmarc_app  # noqa: E402
 from dmarc_msp.cli.retention import app as retention_app  # noqa: E402
 from dmarc_msp.cli.server import app as server_app  # noqa: E402
@@ -43,6 +44,7 @@ app.add_typer(dashboard_app, name="dashboard")
 app.add_typer(dashboard_app, name="dashboards", hidden=True)
 app.add_typer(parsedmarc_app, name="parsedmarc")
 app.add_typer(retention_app, name="retention")
+app.add_typer(migrate_app, name="migrate")
 app.add_typer(server_app, name="server", hidden=True)
 
 

--- a/dmarc_msp/cli/migrate.py
+++ b/dmarc_msp/cli/migrate.py
@@ -1,0 +1,198 @@
+"""One-shot data-migration CLI commands.
+
+These repair existing OpenSearch documents and Dashboards saved objects
+that drifted when parsedmarc renamed ASN fields and improved its IP-based
+enrichment (GeoIP swap to ipinfo, better source-name/type classification).
+All commands are idempotent and safe to re-run.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from dmarc_msp.cli.helpers import get_db_session, get_settings
+from dmarc_msp.services.clients import ClientService
+from dmarc_msp.services.dashboards import DashboardService
+from dmarc_msp.services.migrate import (
+    DEFAULT_ENRICHMENT_FIELDS,
+    DMARC_INDEX_PATTERN,
+    FIELD_TO_PARSEDMARC_KEY,
+    MigrationService,
+)
+
+app = typer.Typer(
+    help="Data-migration commands for existing indices.", no_args_is_help=True
+)
+console = Console()
+
+_DEFAULT_FIELDS_CSV = ",".join(DEFAULT_ENRICHMENT_FIELDS)
+
+
+def _parse_fields(raw: str) -> list[str]:
+    items = [f.strip() for f in raw.split(",") if f.strip()]
+    unknown = [f for f in items if f not in FIELD_TO_PARSEDMARC_KEY]
+    if unknown:
+        supported = ", ".join(sorted(FIELD_TO_PARSEDMARC_KEY))
+        raise typer.BadParameter(f"Unknown field(s): {unknown}. Supported: {supported}")
+    return items
+
+
+@app.command("rename-asn-fields")
+def rename_asn_fields(
+    index_pattern: str = typer.Option(
+        DMARC_INDEX_PATTERN,
+        "--index-pattern",
+        help="Comma-separated OpenSearch index pattern to target.",
+    ),
+    config: str | None = typer.Option(None, "--config", "-c"),
+):
+    """Rename ``source_asn_{name,domain}`` → ``source_as_{name,domain}``
+    in existing documents."""
+    settings = get_settings(config)
+    svc = MigrationService(settings.opensearch, settings.parsedmarc.container)
+    console.print(f"Running ASN rename on [bold]{index_pattern}[/bold]…")
+    result = svc.rename_asn_fields(index_pattern=index_pattern)
+    console.print(
+        f"  scanned: {result.total}  updated: [green]{result.updated}[/green]  "
+        f"failures: {result.failures}"
+    )
+    if result.failures:
+        raise typer.Exit(1)
+
+
+@app.command("refresh-index-fields")
+def refresh_index_fields(
+    client: str | None = typer.Option(
+        None, "--client", help="Refresh fields for a single client (default: all)."
+    ),
+    config: str | None = typer.Option(None, "--config", "-c"),
+):
+    """Rebuild each tenant's cached index-pattern field list from the live
+    mapping. Run this after a parsedmarc upgrade that adds or renames fields."""
+    settings = get_settings(config)
+    db = get_db_session(settings)
+    try:
+        client_svc = ClientService(db)
+        if client:
+            clients = [client_svc.get(client)]
+        else:
+            clients = client_svc.list(include_offboarded=False)
+        if not clients:
+            console.print("No active clients found.")
+            return
+        dash_svc = DashboardService(settings.dashboards, settings.opensearch)
+        failed: list[tuple[str, Exception]] = []
+        for c in clients:
+            try:
+                n = dash_svc.refresh_index_pattern_fields(c.tenant_name)
+                console.print(
+                    f"  [green]✓[/green] {c.name} (tenant={c.tenant_name}) "
+                    f"— refreshed {n} index-pattern(s)"
+                )
+            except Exception as e:
+                failed.append((c.name, e))
+                console.print(f"  [red]✗[/red] {c.name}: {e}")
+        console.print(
+            f"\nRefreshed {len(clients) - len(failed)}/{len(clients)} tenants."
+        )
+        if failed:
+            raise typer.Exit(1)
+    finally:
+        db.close()
+
+
+@app.command("refill-enrichment")
+def refill_enrichment(
+    fields: str = typer.Option(
+        _DEFAULT_FIELDS_CSV,
+        "--fields",
+        help=(
+            "Comma-separated doc fields to re-enrich. Supported: "
+            + ", ".join(sorted(FIELD_TO_PARSEDMARC_KEY))
+        ),
+    ),
+    index_pattern: str = typer.Option(
+        DMARC_INDEX_PATTERN,
+        "--index-pattern",
+        help="Comma-separated OpenSearch index pattern to target.",
+    ),
+    lookup_batch: int = typer.Option(
+        500, "--lookup-batch", help="IPs sent per parsedmarc lookup call."
+    ),
+    update_batch: int = typer.Option(
+        500, "--update-batch", help="IPs grouped per _update_by_query call."
+    ),
+    config: str | None = typer.Option(None, "--config", "-c"),
+):
+    """Re-derive IP-based enrichment fields (country, source_name,
+    source_type) on existing docs by calling parsedmarc's own helper inside
+    the parsedmarc container, so historical data matches what new docs get."""
+    field_list = _parse_fields(fields)
+    settings = get_settings(config)
+    svc = MigrationService(settings.opensearch, settings.parsedmarc.container)
+    console.print(
+        f"Re-enriching {field_list} on [bold]{index_pattern}[/bold] "
+        f"via container [bold]{settings.parsedmarc.container}[/bold]…"
+    )
+    result = svc.refill_enrichment_fields(
+        index_pattern=index_pattern,
+        fields=field_list,
+        lookup_batch=lookup_batch,
+        update_batch=update_batch,
+    )
+    console.print(
+        f"  unique IPs: {result.unique_ips}  resolved: {result.resolved_ips}  "
+        f"docs updated: [green]{result.updated_docs}[/green]"
+    )
+
+
+@app.command("all")
+def run_all(
+    fields: str = typer.Option(
+        _DEFAULT_FIELDS_CSV,
+        "--fields",
+        help="Enrichment fields to re-derive in step 2.",
+    ),
+    config: str | None = typer.Option(None, "--config", "-c"),
+):
+    """Run all three migrations in order: rename ASN fields, re-derive
+    IP-based enrichment, refresh index-pattern fields."""
+    field_list = _parse_fields(fields)
+    settings = get_settings(config)
+
+    svc = MigrationService(settings.opensearch, settings.parsedmarc.container)
+    console.print("[bold]1/3[/bold] Renaming ASN fields…")
+    r1 = svc.rename_asn_fields()
+    console.print(
+        f"    scanned: {r1.total}  updated: [green]{r1.updated}[/green]  "
+        f"failures: {r1.failures}"
+    )
+
+    console.print(f"[bold]2/3[/bold] Re-deriving enrichment ({field_list})…")
+    r2 = svc.refill_enrichment_fields(fields=field_list)
+    console.print(
+        f"    unique IPs: {r2.unique_ips}  resolved: {r2.resolved_ips}  "
+        f"docs updated: [green]{r2.updated_docs}[/green]"
+    )
+
+    console.print("[bold]3/3[/bold] Refreshing index-pattern fields per tenant…")
+    db = get_db_session(settings)
+    try:
+        clients = ClientService(db).list(include_offboarded=False)
+        dash_svc = DashboardService(settings.dashboards, settings.opensearch)
+        failed: list[tuple[str, Exception]] = []
+        for c in clients:
+            try:
+                n = dash_svc.refresh_index_pattern_fields(c.tenant_name)
+                console.print(
+                    f"    [green]✓[/green] {c.name} — refreshed {n} index-pattern(s)"
+                )
+            except Exception as e:
+                failed.append((c.name, e))
+                console.print(f"    [red]✗[/red] {c.name}: {e}")
+    finally:
+        db.close()
+
+    if r1.failures or failed:
+        raise typer.Exit(1)

--- a/dmarc_msp/services/dashboards.py
+++ b/dmarc_msp/services/dashboards.py
@@ -62,6 +62,60 @@ class DashboardService:
         state = "enabled" if enabled else "disabled"
         logger.info("Dark mode %s for tenant=%s", state, tenant_name)
 
+    def refresh_index_pattern_fields(self, tenant_name: str) -> int:
+        """Rebuild the cached ``attributes.fields`` list on every
+        index-pattern saved object in a tenant.
+
+        The template NDJSON ships with a cached field list baked in, which
+        goes stale whenever parsedmarc adds, renames, or removes fields.
+        Dashboards will not auto-refresh — it just shows whatever was in
+        the saved object at import time. This forces a refresh by asking
+        Dashboards for the current mapping-derived fields and writing them
+        back onto the saved object.
+
+        Returns the number of index-patterns refreshed.
+        """
+        headers = {
+            "osd-xsrf": "true",
+            "securitytenant": tenant_name,
+        }
+        meta_fields = ["_source", "_id", "_type", "_index", "_score"]
+        refreshed = 0
+        with httpx.Client(verify=False, auth=self.auth, timeout=60) as client:
+            find = client.get(
+                f"{self.dashboards_url}/api/saved_objects/_find",
+                headers=headers,
+                params={"type": "index-pattern", "per_page": 100},
+            )
+            find.raise_for_status()
+            for obj in find.json().get("saved_objects", []):
+                oid = obj["id"]
+                title = obj.get("attributes", {}).get("title")
+                if not title:
+                    continue
+                fields_resp = client.get(
+                    f"{self.dashboards_url}/api/index_patterns/_fields_for_wildcard",
+                    headers=headers,
+                    params=[("pattern", title)]
+                    + [("meta_fields", m) for m in meta_fields],
+                )
+                fields_resp.raise_for_status()
+                fields = fields_resp.json().get("fields", [])
+                put = client.put(
+                    f"{self.dashboards_url}/api/saved_objects/index-pattern/{oid}",
+                    headers=headers,
+                    json={"attributes": {"fields": json.dumps(fields)}},
+                )
+                put.raise_for_status()
+                logger.info(
+                    "Refreshed %d fields on '%s' in tenant=%s",
+                    len(fields),
+                    title,
+                    tenant_name,
+                )
+                refreshed += 1
+        return refreshed
+
     def _set_tenant_settings(
         self, tenant_name: str, changes: dict[str, object]
     ) -> None:

--- a/dmarc_msp/services/migrate.py
+++ b/dmarc_msp/services/migrate.py
@@ -1,0 +1,398 @@
+"""One-shot data migrations for existing OpenSearch indices.
+
+These commands exist to repair data written by older parsedmarc versions:
+
+* ``rename_asn_fields`` — the old ``source_asn_name`` / ``source_asn_domain``
+  fields were renamed upstream to ``source_as_name`` / ``source_as_domain``.
+  Existing documents still use the old names.
+* ``refill_enrichment_fields`` — parsedmarc's IP-based enrichment has improved
+  (GeoIP swap ipdb → ipinfo, better source-name/type classification). Old
+  documents carry stale values. We call ``parsedmarc.utils.get_ip_address_info``
+  inside the parsedmarc container so old docs get the exact same enrichment
+  new docs get.
+
+``DashboardService.refresh_index_pattern_fields`` handles the third piece
+(refreshing the cached field list inside each tenant's index-pattern saved
+objects) and is invoked by the CLI alongside these two.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+from opensearchpy import NotFoundError, OpenSearch
+
+from dmarc_msp.config import OpenSearchConfig
+
+logger = logging.getLogger(__name__)
+
+# Indices that carry source_ip_address / source_country / ASN / source_name /
+# source_type. smtp_tls reports have a different shape and are excluded.
+DMARC_INDEX_PATTERN = "*_dmarc_aggregate*,*_dmarc_fo*"
+
+# Map OpenSearch doc field names (prefixed with source_) to the keys returned
+# by parsedmarc.utils.get_ip_address_info. Only fields listed here are allowed
+# via --fields; unknown names would have no lookup source.
+FIELD_TO_PARSEDMARC_KEY: dict[str, str] = {
+    "source_country": "country",
+    "source_name": "name",
+    "source_type": "type",
+    "source_as_name": "as_name",
+    "source_as_domain": "as_domain",
+}
+DEFAULT_ENRICHMENT_FIELDS: tuple[str, ...] = tuple(FIELD_TO_PARSEDMARC_KEY.keys())
+
+# Painless move-field script: if the old field exists, copy to the new name
+# and remove the old one. ctx.op='noop' when neither field is present keeps
+# the cluster from touching docs that are already on the new schema.
+_RENAME_ASN_SCRIPT = """
+boolean changed = false;
+if (ctx._source.containsKey('source_asn_name')) {
+    ctx._source.source_as_name = ctx._source.remove('source_asn_name');
+    changed = true;
+}
+if (ctx._source.containsKey('source_asn_domain')) {
+    ctx._source.source_as_domain = ctx._source.remove('source_asn_domain');
+    changed = true;
+}
+if (!changed) { ctx.op = 'noop'; }
+""".strip()
+
+# Painless patch script: for each doc, look up its source_ip_address in the
+# caller-supplied map; if there's an entry, overwrite any target fields that
+# differ. Uses ctx.op='noop' when there's nothing to do so the cluster skips
+# writing the doc entirely.
+_ENRICHMENT_PATCH_SCRIPT = """
+if (ctx._source.source_ip_address == null) { ctx.op = 'noop'; return; }
+String ip = ctx._source.source_ip_address;
+if (!params.ip_to_enrichment.containsKey(ip)) { ctx.op = 'noop'; return; }
+Map enrichment = params.ip_to_enrichment.get(ip);
+boolean changed = false;
+for (entry in enrichment.entrySet()) {
+    String f = entry.getKey();
+    def v = entry.getValue();
+    if (v == null) { continue; }
+    def existing = ctx._source.get(f);
+    if (existing == null || !v.equals(existing)) {
+        ctx._source.put(f, v);
+        changed = true;
+    }
+}
+if (!changed) { ctx.op = 'noop'; }
+""".strip()
+
+# Script run inside the parsedmarc container. Reads a JSON list of IPs from
+# stdin and writes a JSON dict {ip: info_dict_or_null} to stdout. offline=True
+# skips DNS/WHOIS so we only hit the local GeoIP DB and name/type classifier.
+_PARSEDMARC_LOOKUP_SCRIPT = r"""
+import json, sys
+from parsedmarc.utils import get_ip_address_info
+
+ips = json.load(sys.stdin)
+out = {}
+for ip in ips:
+    try:
+        info = get_ip_address_info(ip, offline=True, parallel=False)
+        out[ip] = info
+    except Exception as exc:
+        out[ip] = None
+        print(f"lookup-failed {ip}: {exc}", file=sys.stderr)
+json.dump(out, sys.stdout)
+"""
+
+
+@dataclass
+class RenameAsnResult:
+    total: int
+    updated: int
+    failures: int
+
+
+@dataclass
+class EnrichmentFixResult:
+    unique_ips: int
+    resolved_ips: int
+    updated_docs: int
+    fields_requested: list[str] = field(default_factory=list)
+
+
+class MigrationService:
+    """One-shot data-repair operations against existing OpenSearch data."""
+
+    def __init__(
+        self,
+        opensearch_config: OpenSearchConfig,
+        parsedmarc_container: str = "parsedmarc",
+    ):
+        self.client = OpenSearch(
+            hosts=[opensearch_config.hosts],
+            http_auth=(
+                opensearch_config.username,
+                opensearch_config.resolved_password,
+            ),
+            use_ssl=opensearch_config.ssl,
+            verify_certs=opensearch_config.verify_certs,
+            ssl_show_warn=False,
+        )
+        self.parsedmarc_container = parsedmarc_container
+
+    # ── 1. Rename source_asn_* → source_as_* ──────────────────────────
+
+    def rename_asn_fields(
+        self,
+        index_pattern: str = DMARC_INDEX_PATTERN,
+        poll_interval: float = 2.0,
+    ) -> RenameAsnResult:
+        """Rewrite docs where source_asn_{name,domain} exist to use
+        source_as_{name,domain}. Safe to re-run; no-op on clean docs."""
+        body = {
+            "query": {
+                "bool": {
+                    "should": [
+                        {"exists": {"field": "source_asn_name"}},
+                        {"exists": {"field": "source_asn_domain"}},
+                    ],
+                    "minimum_should_match": 1,
+                }
+            },
+            "script": {"source": _RENAME_ASN_SCRIPT, "lang": "painless"},
+        }
+        logger.info("Starting ASN rename update_by_query on '%s'", index_pattern)
+        response = self.client.transport.perform_request(
+            "POST",
+            f"/{index_pattern}/_update_by_query",
+            params={
+                "conflicts": "proceed",
+                "wait_for_completion": "false",
+                "refresh": "true",
+                "slices": "auto",
+            },
+            body=body,
+        )
+        task_id = response["task"]
+        status = self._wait_for_task(task_id, poll_interval)
+        return RenameAsnResult(
+            total=status.get("total", 0),
+            updated=status.get("updated", 0),
+            failures=len(status.get("failures", [])),
+        )
+
+    # ── 2. Re-enrich source_country / source_name / source_type ───────
+
+    def refill_enrichment_fields(
+        self,
+        index_pattern: str = DMARC_INDEX_PATTERN,
+        fields: list[str] | tuple[str, ...] = DEFAULT_ENRICHMENT_FIELDS,
+        lookup_batch: int = 500,
+        update_batch: int = 500,
+        poll_interval: float = 2.0,
+    ) -> EnrichmentFixResult:
+        """Collect every unique source_ip_address in ``index_pattern``,
+        look up each IP via ``parsedmarc.utils.get_ip_address_info`` inside
+        the parsedmarc container, and update_by_query to overwrite the
+        requested doc fields where they differ.
+
+        ``fields`` must be doc-side names (e.g. ``source_country``); unknown
+        names raise ValueError.
+        """
+        unknown = [f for f in fields if f not in FIELD_TO_PARSEDMARC_KEY]
+        if unknown:
+            raise ValueError(
+                f"Unknown enrichment field(s): {unknown}. "
+                f"Supported: {sorted(FIELD_TO_PARSEDMARC_KEY)}"
+            )
+        if not fields:
+            raise ValueError("At least one enrichment field must be specified")
+
+        ips = sorted(self._collect_source_ips(index_pattern))
+        if not ips:
+            logger.info("No source_ip_address values found in '%s'", index_pattern)
+            return EnrichmentFixResult(0, 0, 0, list(fields))
+        logger.info(
+            "Collected %d unique source IPs from '%s' for fields %s",
+            len(ips),
+            index_pattern,
+            list(fields),
+        )
+
+        ip_to_enrichment: dict[str, dict[str, str]] = {}
+        for start in range(0, len(ips), lookup_batch):
+            chunk = ips[start : start + lookup_batch]
+            results = self._lookup_enrichment(chunk)
+            for ip, info in results.items():
+                if not info:
+                    continue
+                patch = {}
+                for doc_field in fields:
+                    pm_key = FIELD_TO_PARSEDMARC_KEY[doc_field]
+                    val = info.get(pm_key)
+                    if val:
+                        patch[doc_field] = val
+                if patch:
+                    ip_to_enrichment[ip] = patch
+            logger.info(
+                "Looked up %d/%d IPs (resolved %d so far)",
+                min(start + lookup_batch, len(ips)),
+                len(ips),
+                len(ip_to_enrichment),
+            )
+
+        if not ip_to_enrichment:
+            logger.warning(
+                "No enrichment values resolved for fields %s; nothing to patch",
+                list(fields),
+            )
+            return EnrichmentFixResult(len(ips), 0, 0, list(fields))
+
+        updated_docs = 0
+        resolved_ips = sorted(ip_to_enrichment.keys())
+        for start in range(0, len(resolved_ips), update_batch):
+            chunk = resolved_ips[start : start + update_batch]
+            chunk_map = {ip: ip_to_enrichment[ip] for ip in chunk}
+            updated_docs += self._apply_enrichment_patch(
+                index_pattern, chunk_map, poll_interval
+            )
+            logger.info(
+                "Patched %d/%d IP buckets (docs updated so far: %d)",
+                min(start + update_batch, len(resolved_ips)),
+                len(resolved_ips),
+                updated_docs,
+            )
+
+        return EnrichmentFixResult(
+            unique_ips=len(ips),
+            resolved_ips=len(ip_to_enrichment),
+            updated_docs=updated_docs,
+            fields_requested=list(fields),
+        )
+
+    # ── Internals ─────────────────────────────────────────────────────
+
+    def _collect_source_ips(self, index_pattern: str) -> set[str]:
+        """Return the set of unique source_ip_address values across the
+        matching indices. Uses a composite terms aggregation so it scales
+        past the 10k terms-agg default without loading every doc."""
+        ips: set[str] = set()
+        after: dict | None = None
+        while True:
+            body: dict = {
+                "size": 0,
+                "aggs": {
+                    "ips": {
+                        "composite": {
+                            "size": 1000,
+                            "sources": [
+                                {"ip": {"terms": {"field": "source_ip_address"}}}
+                            ],
+                        }
+                    }
+                },
+            }
+            if after is not None:
+                body["aggs"]["ips"]["composite"]["after"] = after
+            try:
+                resp = self.client.transport.perform_request(
+                    "POST",
+                    f"/{index_pattern}/_search",
+                    body=body,
+                )
+            except NotFoundError:
+                logger.warning("Index pattern '%s' matched nothing", index_pattern)
+                return ips
+            buckets = resp.get("aggregations", {}).get("ips", {}).get("buckets", [])
+            if not buckets:
+                break
+            for b in buckets:
+                ip = b["key"].get("ip")
+                if ip:
+                    ips.add(ip)
+            after = resp["aggregations"]["ips"].get("after_key")
+            if after is None:
+                break
+        return ips
+
+    def _lookup_enrichment(self, ips: list[str]) -> dict[str, dict | None]:
+        """Run the parsedmarc geoip helper inside the parsedmarc container
+        and return {ip: info_dict_or_None}."""
+        try:
+            proc = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    "-i",
+                    self.parsedmarc_container,
+                    "python3",
+                    "-c",
+                    _PARSEDMARC_LOOKUP_SCRIPT,
+                ],
+                input=json.dumps(ips),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "Docker CLI not found. The migrate command must run where "
+                "the parsedmarc container is reachable via 'docker exec'."
+            ) from e
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"parsedmarc enrichment lookup failed (exit {e.returncode}): "
+                f"{e.stderr.strip() or e.stdout.strip()}"
+            ) from e
+        if proc.stderr.strip():
+            logger.debug("parsedmarc lookup stderr: %s", proc.stderr.strip())
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Could not parse parsedmarc lookup output: {e}\n"
+                f"stdout: {proc.stdout[:500]}"
+            ) from e
+
+    def _apply_enrichment_patch(
+        self,
+        index_pattern: str,
+        ip_to_enrichment: dict[str, dict[str, str]],
+        poll_interval: float,
+    ) -> int:
+        body = {
+            "query": {"terms": {"source_ip_address": list(ip_to_enrichment.keys())}},
+            "script": {
+                "source": _ENRICHMENT_PATCH_SCRIPT,
+                "lang": "painless",
+                "params": {"ip_to_enrichment": ip_to_enrichment},
+            },
+        }
+        response = self.client.transport.perform_request(
+            "POST",
+            f"/{index_pattern}/_update_by_query",
+            params={
+                "conflicts": "proceed",
+                "wait_for_completion": "false",
+                "refresh": "true",
+                "slices": "auto",
+            },
+            body=body,
+        )
+        status = self._wait_for_task(response["task"], poll_interval)
+        return status.get("updated", 0)
+
+    def _wait_for_task(self, task_id: str, poll_interval: float) -> dict:
+        while True:
+            resp = self.client.transport.perform_request("GET", f"/_tasks/{task_id}")
+            if resp.get("completed"):
+                response = resp.get("response", {})
+                failures = response.get("failures", [])
+                if failures:
+                    logger.warning(
+                        "update_by_query completed with %d failure(s): %s",
+                        len(failures),
+                        failures[:3],
+                    )
+                return response
+            time.sleep(poll_interval)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dmarc-msp"
-version = "0.6.0"
+version = "0.6.1"
 description = "DMARC monitoring automation for Managed Service Providers (and everyone else)"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_services/test_opensearch.py
+++ b/tests/test_services/test_opensearch.py
@@ -220,7 +220,12 @@ def test_update_internal_user_password_preserves_backend_roles():
     """Admin-set backend_roles must survive a password update."""
     svc, mock_client = _make_service()
     mock_client.transport.perform_request.side_effect = [
-        {"analyst1": {"attributes": {"role_type": "analyst"}, "backend_roles": ["br1"]}},
+        {
+            "analyst1": {
+                "attributes": {"role_type": "analyst"},
+                "backend_roles": ["br1"],
+            }
+        },
         None,  # PUT
     ]
     svc.update_internal_user_password("analyst1", "newpass")


### PR DESCRIPTION
## Summary

- Adds `dmarcmsp migrate` CLI group with four commands (`rename-asn-fields`, `refill-enrichment`, `refresh-index-fields`, `all`) to repair existing OpenSearch indices after the parsedmarc upgrade that renamed `source_asn_*` → `source_as_*`, swapped ipdb → ipinfo for GeoIP, and improved the IP-based source-name/type classifier.
- `refill-enrichment` delegates to `parsedmarc.utils.get_ip_address_info` inside the parsedmarc container so historical docs receive the exact same enrichment new docs do. Default fields: `source_country, source_name, source_type, source_as_name, source_as_domain`.
- Bumps to 0.6.1 and updates CHANGELOG.

## Test plan

- [x] `pytest` — 270 passed
- [x] `ruff check` / `ruff format` clean on changed files
- [ ] After merge: run `dmarcmsp migrate all` in production and verify docs/index-patterns are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)