### PR TITLE
Release 0.6.2: fix migrate refill-enrichment on keyword subfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.2 2026-04-23
+
+### Fixed
+
+- `dmarcmsp migrate refill-enrichment` (and `migrate all`) no longer fails
+  with a `fielddata` error. The composite aggregation that collects unique
+  source IPs and the terms filter that targets docs for the patch step
+  both now use `source_ip_address.keyword` instead of the text field.
+
 ## 0.6.1 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   with a `fielddata` error. The composite aggregation that collects unique
   source IPs and the terms filter that targets docs for the patch step
   both now use `source_ip_address.keyword` instead of the text field.
+- `dmarcmsp migrate rename-asn-fields` now refreshes each tenant's cached
+  index-pattern field list after the rename, so Discover stops warning that
+  `source_as_name` / `source_as_domain` have no cached mapping. Pass
+  `--skip-refresh` to opt out.
 
 ## 0.6.1 2026-04-23
 

--- a/dmarc_msp/cli/migrate.py
+++ b/dmarc_msp/cli/migrate.py
@@ -38,6 +38,24 @@ def _parse_fields(raw: str) -> list[str]:
     return items
 
 
+def _refresh_tenant_index_patterns(settings, clients, indent: str = "  ") -> int:
+    """Rebuild each tenant's cached index-pattern field list. Returns the
+    number of tenants that failed."""
+    dash_svc = DashboardService(settings.dashboards, settings.opensearch)
+    failed = 0
+    for c in clients:
+        try:
+            n = dash_svc.refresh_index_pattern_fields(c.tenant_name)
+            console.print(
+                f"{indent}[green]✓[/green] {c.name} (tenant={c.tenant_name}) "
+                f"— refreshed {n} index-pattern(s)"
+            )
+        except Exception as e:
+            failed += 1
+            console.print(f"{indent}[red]✗[/red] {c.name}: {e}")
+    return failed
+
+
 @app.command("rename-asn-fields")
 def rename_asn_fields(
     index_pattern: str = typer.Option(
@@ -45,10 +63,16 @@ def rename_asn_fields(
         "--index-pattern",
         help="Comma-separated OpenSearch index pattern to target.",
     ),
+    skip_refresh: bool = typer.Option(
+        False,
+        "--skip-refresh",
+        help="Don't refresh Dashboards index-pattern field caches afterward.",
+    ),
     config: str | None = typer.Option(None, "--config", "-c"),
 ):
     """Rename ``source_asn_{name,domain}`` → ``source_as_{name,domain}``
-    in existing documents."""
+    in existing documents, then refresh each tenant's cached index-pattern
+    fields so Discover picks up the new field names."""
     settings = get_settings(config)
     svc = MigrationService(settings.opensearch, settings.parsedmarc.container)
     console.print(f"Running ASN rename on [bold]{index_pattern}[/bold]…")
@@ -57,7 +81,17 @@ def rename_asn_fields(
         f"  scanned: {result.total}  updated: [green]{result.updated}[/green]  "
         f"failures: {result.failures}"
     )
-    if result.failures:
+    refresh_failed = 0
+    if not skip_refresh:
+        db = get_db_session(settings)
+        try:
+            clients = ClientService(db).list(include_offboarded=False)
+            if clients:
+                console.print("Refreshing index-pattern fields per tenant…")
+                refresh_failed = _refresh_tenant_index_patterns(settings, clients)
+        finally:
+            db.close()
+    if result.failures or refresh_failed:
         raise typer.Exit(1)
 
 
@@ -81,21 +115,8 @@ def refresh_index_fields(
         if not clients:
             console.print("No active clients found.")
             return
-        dash_svc = DashboardService(settings.dashboards, settings.opensearch)
-        failed: list[tuple[str, Exception]] = []
-        for c in clients:
-            try:
-                n = dash_svc.refresh_index_pattern_fields(c.tenant_name)
-                console.print(
-                    f"  [green]✓[/green] {c.name} (tenant={c.tenant_name}) "
-                    f"— refreshed {n} index-pattern(s)"
-                )
-            except Exception as e:
-                failed.append((c.name, e))
-                console.print(f"  [red]✗[/red] {c.name}: {e}")
-        console.print(
-            f"\nRefreshed {len(clients) - len(failed)}/{len(clients)} tenants."
-        )
+        failed = _refresh_tenant_index_patterns(settings, clients)
+        console.print(f"\nRefreshed {len(clients) - failed}/{len(clients)} tenants.")
         if failed:
             raise typer.Exit(1)
     finally:
@@ -180,17 +201,7 @@ def run_all(
     db = get_db_session(settings)
     try:
         clients = ClientService(db).list(include_offboarded=False)
-        dash_svc = DashboardService(settings.dashboards, settings.opensearch)
-        failed: list[tuple[str, Exception]] = []
-        for c in clients:
-            try:
-                n = dash_svc.refresh_index_pattern_fields(c.tenant_name)
-                console.print(
-                    f"    [green]✓[/green] {c.name} — refreshed {n} index-pattern(s)"
-                )
-            except Exception as e:
-                failed.append((c.name, e))
-                console.print(f"    [red]✗[/red] {c.name}: {e}")
+        failed = _refresh_tenant_index_patterns(settings, clients, indent="    ")
     finally:
         db.close()
 

--- a/dmarc_msp/services/migrate.py
+++ b/dmarc_msp/services/migrate.py
@@ -275,7 +275,12 @@ class MigrationService:
     def _collect_source_ips(self, index_pattern: str) -> set[str]:
         """Return the set of unique source_ip_address values across the
         matching indices. Uses a composite terms aggregation so it scales
-        past the 10k terms-agg default without loading every doc."""
+        past the 10k terms-agg default without loading every doc.
+
+        parsedmarc's dynamic mapping stores source_ip_address as text with a
+        ``.keyword`` subfield; aggregating on text fields is disabled by
+        default, hence the ``.keyword`` target.
+        """
         ips: set[str] = set()
         after: dict | None = None
         while True:
@@ -286,7 +291,11 @@ class MigrationService:
                         "composite": {
                             "size": 1000,
                             "sources": [
-                                {"ip": {"terms": {"field": "source_ip_address"}}}
+                                {
+                                    "ip": {
+                                        "terms": {"field": "source_ip_address.keyword"}
+                                    }
+                                }
                             ],
                         }
                     }
@@ -361,7 +370,9 @@ class MigrationService:
         poll_interval: float,
     ) -> int:
         body = {
-            "query": {"terms": {"source_ip_address": list(ip_to_enrichment.keys())}},
+            "query": {
+                "terms": {"source_ip_address.keyword": list(ip_to_enrichment.keys())}
+            },
             "script": {
                 "source": _ENRICHMENT_PATCH_SCRIPT,
                 "lang": "painless",

--- a/dmarc_msp/services/migrate.py
+++ b/dmarc_msp/services/migrate.py
@@ -277,9 +277,9 @@ class MigrationService:
         matching indices. Uses a composite terms aggregation so it scales
         past the 10k terms-agg default without loading every doc.
 
-        parsedmarc's dynamic mapping stores source_ip_address as text with a
-        ``.keyword`` subfield; aggregating on text fields is disabled by
-        default, hence the ``.keyword`` target.
+        parsedmarc's dynamic mapping gives every string field a ``.keyword``
+        subfield; aggregations and terms filters on the text field fail with
+        a fielddata error, so we always target ``<field>.keyword``.
         """
         ips: set[str] = set()
         after: dict | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dmarc-msp"
-version = "0.6.1"
+version = "0.6.2"
 description = "DMARC monitoring automation for Managed Service Providers (and everyone else)"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Follow-up to 0.6.1.

- `migrate refill-enrichment` / `migrate all` fail at runtime because parsedmarc's dynamic mapping stores `source_ip_address` as text (with a `.keyword` subfield), and OpenSearch disables aggregations/sorts on text fields by default. Both the composite terms aggregation that collects unique IPs and the terms filter that scopes the `_update_by_query` patch now target `source_ip_address.keyword`. (`.keyword` is a blanket property of parsedmarc's dynamic string mapping — the comment in `_collect_source_ips` is corrected accordingly.)
- `migrate rename-asn-fields` left OSD Discover warning that `source_as_name` / `source_as_domain` had no cached mapping, because the per-tenant index-pattern saved objects still listed the old field names. The command now refreshes each active tenant's cached field list after the rename. Pass `--skip-refresh` to opt out. The per-tenant refresh loop is factored into a helper shared with `refresh-index-fields` and `migrate all`.

## Test plan

- [x] `pytest` — 270 passed
- [x] `ruff check` / `ruff format --check` clean
- [ ] After merge: re-run `dmarcmsp migrate all` in production and confirm step 2 (refill-enrichment) progresses past the aggregation and step 3 (refresh) runs cleanly
- [ ] After merge: open OSD Discover in a client tenant and confirm `source_as_name` / `source_as_domain` no longer show the "no cached mapping" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)