### PR TITLE
Fix dashboard import silently skipping updates: log errors + --replace flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.4 2026-04-23
+
+### Added
+
+- `dmarcmsp dashboard import` and `import-all` now accept `--replace`,
+  which deletes every template saved object from the tenant by (type, id)
+  before running the import. Useful when OSD's `_import?overwrite=true`
+  silently skips updates — e.g. a pre-existing dashboard that won't pick
+  up a newly added panel — and as a way to force a clean re-sync. Only
+  IDs present in the template are touched; user-created saved objects in
+  the tenant are left alone.
+
+### Fixed
+
+- `DashboardService._import_saved_objects` now logs per-object import
+  errors and a `successCount` vs. expected-count line on every run. OSD's
+  `_import` API returns top-level `success: true` even when individual
+  objects were skipped (version conflicts, broken refs, etc.), so the
+  caller never saw those failures. Surfaces the same class of problem
+  that masked the "Message sources by Autonomous System" visualization
+  silently not landing in existing tenants.
+
 ## 0.6.3 2026-04-23
 
 ### Fixed

--- a/dmarc_msp/cli/dashboard.py
+++ b/dmarc_msp/cli/dashboard.py
@@ -16,6 +16,15 @@ console = Console()
 @app.command("import")
 def import_dashboards(
     client: str = typer.Argument(..., help="Client name"),
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help=(
+            "Delete every template saved object from the tenant before "
+            "importing. Use when an overwrite import silently fails to "
+            "update a dashboard or visualization."
+        ),
+    ),
     config: str | None = typer.Option(None, "--config", "-c"),
 ):
     """Import dashboards into a client's tenant."""
@@ -25,7 +34,9 @@ def import_dashboards(
         client_svc = ClientService(db)
         client_row = client_svc.get(client)
         dash_svc = DashboardService(settings.dashboards, settings.opensearch)
-        dash_svc.import_for_client(client_row.tenant_name, client_row.index_prefix)
+        dash_svc.import_for_client(
+            client_row.tenant_name, client_row.index_prefix, replace=replace
+        )
         console.print(
             f"Imported dashboards for [bold]{client_row.name}[/bold] "
             f"(tenant={client_row.tenant_name})"
@@ -65,6 +76,15 @@ def dark_mode(
 
 @app.command("import-all")
 def import_all_dashboards(
+    replace: bool = typer.Option(
+        False,
+        "--replace",
+        help=(
+            "Delete every template saved object from each tenant before "
+            "importing. Use when an overwrite import silently fails to "
+            "update a dashboard or visualization."
+        ),
+    ),
     config: str | None = typer.Option(None, "--config", "-c"),
 ):
     """Re-import dashboards into every active client's tenant."""
@@ -82,7 +102,9 @@ def import_all_dashboards(
         for client_row in clients:
             try:
                 dash_svc.import_for_client(
-                    client_row.tenant_name, client_row.index_prefix
+                    client_row.tenant_name,
+                    client_row.index_prefix,
+                    replace=replace,
                 )
                 console.print(
                     f"  [green]✓[/green] {client_row.name} "

--- a/dmarc_msp/services/dashboards.py
+++ b/dmarc_msp/services/dashboards.py
@@ -32,9 +32,24 @@ class DashboardService:
         self.dark_mode = dashboards_config.dark_mode
         self.import_failure_reports = dashboards_config.import_failure_reports
 
-    def import_for_client(self, tenant_name: str, index_prefix: str) -> None:
+    def import_for_client(
+        self,
+        tenant_name: str,
+        index_prefix: str,
+        *,
+        replace: bool = False,
+    ) -> None:
         """Rewrite the template NDJSON with the client's index prefix
-        and import into their tenant."""
+        and import into their tenant.
+
+        When ``replace`` is True, every template saved object is deleted
+        from the tenant before the import runs. Use this to work around
+        cases where ``_import?overwrite=true`` silently skips updates —
+        e.g. OSD's version-conflict handling on an existing dashboard —
+        or to guarantee the tenant's template objects exactly match the
+        current NDJSON. Only the IDs present in the template are touched;
+        user-created saved objects in the tenant are left alone.
+        """
         if not self.template_path.exists():
             raise FileNotFoundError(
                 f"Dashboard template not found: {self.template_path}"
@@ -43,6 +58,8 @@ class DashboardService:
         rewritten = self._rewrite_template(index_prefix)
         if not self.import_failure_reports:
             self._delete_failure_objects(tenant_name, index_prefix)
+        if replace:
+            self._delete_template_objects(tenant_name, rewritten)
         self._import_saved_objects(tenant_name, rewritten)
         default_index_id = self._find_default_index_id(rewritten)
         settings: dict[str, object] = {}
@@ -257,16 +274,38 @@ class DashboardService:
             for obj in all_objects
             if obj.get("id") and obj.get("id") not in kept_ids
         ]
+        self._delete_saved_objects(tenant_name, failure_objects)
 
-        if not failure_objects:
+    def _delete_template_objects(self, tenant_name: str, ndjson: str) -> None:
+        """Delete every template saved object from a tenant, keyed by the
+        (type, id) pairs in the already-rewritten NDJSON. Used by
+        ``replace=True`` so the subsequent import starts from a clean slate
+        and is unaffected by OSD's version-conflict handling on overwrite.
+        User-created saved objects (IDs not in the template) are untouched.
+        """
+        objects = [
+            json.loads(line)
+            for line in ndjson.split("\n")
+            if line.strip() and line.lstrip().startswith("{")
+        ]
+        template_objects = [
+            obj for obj in objects if obj.get("id") and obj.get("type")
+        ]
+        self._delete_saved_objects(tenant_name, template_objects)
+
+    def _delete_saved_objects(
+        self, tenant_name: str, objects: list[dict]
+    ) -> None:
+        """Delete a list of saved objects from a tenant by (type, id).
+        Objects that don't exist (404) are treated as already gone."""
+        if not objects:
             return
-
         headers = {
             "osd-xsrf": "true",
             "securitytenant": tenant_name,
         }
         with httpx.Client(verify=False, auth=self.auth, timeout=30) as client:
-            for obj in failure_objects:
+            for obj in objects:
                 obj_type = obj["type"]
                 obj_id = obj["id"]
                 url = f"{self.dashboards_url}/api/saved_objects/{obj_type}/{obj_id}"

--- a/dmarc_msp/services/dashboards.py
+++ b/dmarc_msp/services/dashboards.py
@@ -298,7 +298,27 @@ class DashboardService:
             response.raise_for_status()
             result = response.json()
 
+        # Count imported objects for visibility — OSD's _import returns
+        # success=true even when individual objects were skipped or failed,
+        # so "the call didn't raise" is not the same as "every object landed".
+        expected = sum(1 for line in ndjson.split("\n") if line.strip())
+        success_count = result.get("successCount", 0)
+        errors = result.get("errors", [])
+        logger.info(
+            "Imported %d/%d saved objects into tenant=%s (errors: %d)",
+            success_count,
+            expected,
+            tenant_name,
+            len(errors),
+        )
+        if errors:
+            # Surface per-object errors even when success=true: OSD counts
+            # conflicts/skips here without flipping the top-level flag.
+            logger.warning(
+                "Saved-object import had %d per-object issue(s) in tenant=%s: %s",
+                len(errors),
+                tenant_name,
+                errors,
+            )
         if not result.get("success", False):
-            errors = result.get("errors", [])
-            logger.error("Dashboard import errors: %s", errors)
             raise RuntimeError(f"Dashboard import failed: {errors}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dmarc-msp"
-version = "0.6.3"
+version = "0.6.4"
 description = "DMARC monitoring automation for Managed Service Providers (and everyone else)"
 license = "Apache-2.0"
 readme = "README.md"

--- a/tests/test_services/test_dashboards.py
+++ b/tests/test_services/test_dashboards.py
@@ -283,6 +283,109 @@ def test_import_deletes_failure_objects_from_existing_tenant(tmp_path):
         assert not any("agg-id" in url for url in deleted_urls)
 
 
+def test_import_for_client_replace_deletes_all_template_ids(tmp_path):
+    """With ``replace=True`` every template object is deleted from the
+    tenant by (type, id) before import. Used to bypass OSD's silent
+    failure mode when _import?overwrite=true skips updates."""
+    lines = [
+        json.dumps(
+            {
+                "type": "index-pattern",
+                "id": "agg-id",
+                "attributes": {"title": "dmarc_aggregate*"},
+                "references": [],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "visualization",
+                "id": "viz-id",
+                "attributes": {"title": "Some viz"},
+                "references": [
+                    {"id": "agg-id", "name": "index", "type": "index-pattern"}
+                ],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "dashboard",
+                "id": "dash-id",
+                "attributes": {"title": "Some dashboard"},
+                "references": [
+                    {"id": "viz-id", "name": "panel_0", "type": "visualization"}
+                ],
+            }
+        ),
+    ]
+    svc = _make_template(tmp_path, lines)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"success": True}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("dmarc_msp.services.dashboards.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client.delete.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        svc.import_for_client("acme_tenant", "acme_corp", replace=True)
+
+        deleted_urls = [call.args[0] for call in mock_client.delete.call_args_list]
+        assert any("index-pattern/agg-id" in u for u in deleted_urls)
+        assert any("visualization/viz-id" in u for u in deleted_urls)
+        assert any("dashboard/dash-id" in u for u in deleted_urls)
+
+
+def test_import_for_client_no_replace_does_not_delete_template(tmp_path):
+    """Without ``replace=True`` the template IDs are not deleted. Only
+    failure objects (which are deleted by a separate path when
+    import_failure_reports=False) should be removed."""
+    lines = [
+        json.dumps(
+            {
+                "type": "index-pattern",
+                "id": "agg-id",
+                "attributes": {"title": "dmarc_aggregate*"},
+                "references": [],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "visualization",
+                "id": "viz-id",
+                "attributes": {"title": "Some viz"},
+                "references": [
+                    {"id": "agg-id", "name": "index", "type": "index-pattern"}
+                ],
+            }
+        ),
+    ]
+    svc = _make_template(tmp_path, lines)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"success": True}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("dmarc_msp.services.dashboards.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client.delete.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        svc.import_for_client("acme_tenant", "acme_corp")  # replace defaults False
+
+        deleted_urls = [call.args[0] for call in mock_client.delete.call_args_list]
+        assert not any("agg-id" in u for u in deleted_urls)
+        assert not any("viz-id" in u for u in deleted_urls)
+
+
 def test_import_for_client_sets_default_index(tmp_path):
     """The aggregate index-pattern ID is set as defaultIndex during import."""
     lines = [


### PR DESCRIPTION
## Summary

- **Log per-object errors from OSD's `_import` API.** Previously we only raised when `success: false`, but OSD returns `success: true` even when individual objects were skipped (version conflicts, broken refs). Now we log `successCount / expected` every run and warn on any per-object `errors[]`. Surfaces the failure mode that masked the new "Message sources by Autonomous System" visualization silently not landing in existing tenants.
- **New `--replace` flag on `dmarcmsp dashboard import` / `import-all`.** Deletes every template saved object from the tenant by (type, id) before running the import, so the subsequent `_import` creates rather than updates. Works around OSD's silent-skip behavior on overwrites. User-created saved objects in the tenant are left alone — only IDs present in the template are touched.
- Refactored the existing per-object delete loop out of `_delete_failure_objects` into a shared `_delete_saved_objects` helper so the replace path and the failure-object path use the same 404-tolerant delete behavior.
- Version bumped to 0.6.4.

## Test plan

- [ ] `pytest tests/test_services/test_dashboards.py` passes locally (done: 14/14)
- [ ] Full suite passes (done: 277/277)
- [ ] Run `dmarcmsp dashboard import-all` without `--replace` and confirm the new log line shows `successCount / expected` and any per-object errors
- [ ] Run `dmarcmsp dashboard import-all --replace` and confirm the "Message sources by Autonomous System" viz and its panel appear on the DMARC aggregate reports dashboard in each tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)