### PR TITLE
Preserve template fields absent from the live mapping on refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 0.6.6 2026-04-25
 
+### Fixed
+
+- `refresh_index_pattern_fields` (and the auto-refresh that runs at the
+  end of every dashboard import) no longer strips template-defined
+  fields that aren't yet in the live OpenSearch mapping. parsedmarc
+  only writes nested fields like `policies.failure_details.*` to the
+  mapping when an actual TLSRPT report contains failure details, so
+  tenants with no failure data had those fields silently removed from
+  the cached field list — the new "Failure details" SMTP TLS
+  visualization then rendered "Could not locate that
+  index-pattern-field (id: …)" instead of "no data". Refresh now
+  unions the live response with the template's baked-in
+  `attributes.fields`, with live winning on conflict.
+
 ### Changed
 
 - Refreshed `opensearch/opensearch_dashboards.ndjson` to match upstream

--- a/dmarc_msp/services/dashboards.py
+++ b/dmarc_msp/services/dashboards.py
@@ -111,8 +111,19 @@ class DashboardService:
         Dashboards for the current mapping-derived fields and writing them
         back onto the saved object.
 
+        The live mapping is unioned with the template's baked-in fields:
+        live wins on conflict, but template fields absent from live are
+        preserved. parsedmarc adds nested fields like
+        ``policies.failure_details.*`` to the mapping only when a doc with
+        that data arrives, so a tenant with no failure reports yet has a
+        live mapping that's a strict subset of the template. Without the
+        union, refresh would strip those fields and the SMTP TLS dashboard
+        would render "Could not locate that index-pattern-field" instead
+        of "no data".
+
         Returns the number of index-patterns refreshed.
         """
+        template_fields_by_id = self._load_template_fields_by_id()
         headers = {
             "osd-xsrf": "true",
             "securitytenant": tenant_name,
@@ -139,6 +150,12 @@ class DashboardService:
                 )
                 fields_resp.raise_for_status()
                 fields = fields_resp.json().get("fields", [])
+                template_fields = template_fields_by_id.get(oid, [])
+                if template_fields:
+                    live_names = {f.get("name") for f in fields}
+                    fields = list(fields) + [
+                        tf for tf in template_fields if tf.get("name") not in live_names
+                    ]
                 put = client.put(
                     f"{self.dashboards_url}/api/saved_objects/index-pattern/{oid}",
                     headers=headers,
@@ -153,6 +170,34 @@ class DashboardService:
                 )
                 refreshed += 1
         return refreshed
+
+    def _load_template_fields_by_id(self) -> dict[str, list[dict]]:
+        """Return ``{index_pattern_id: [field, ...]}`` from the bundled
+        NDJSON's baked-in ``attributes.fields`` strings. Used by
+        :meth:`refresh_index_pattern_fields` to preserve fields that the
+        template defines but the live mapping doesn't yet expose."""
+        if not self.template_path.exists():
+            return {}
+        by_id: dict[str, list[dict]] = {}
+        for line in self.template_path.read_text().splitlines():
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") != "index-pattern":
+                continue
+            oid = obj.get("id")
+            fields_str = obj.get("attributes", {}).get("fields")
+            if not oid or not fields_str:
+                continue
+            try:
+                by_id[oid] = json.loads(fields_str)
+            except json.JSONDecodeError:
+                continue
+        return by_id
 
     def delete_orphaned_visualizations(
         self,

--- a/tests/test_services/test_dashboards.py
+++ b/tests/test_services/test_dashboards.py
@@ -636,6 +636,147 @@ def test_delete_orphaned_visualizations_skips_missing_objects(tmp_path):
     mock_client.delete.assert_not_called()
 
 
+def test_refresh_index_pattern_fields_preserves_template_fields_absent_from_live(
+    tmp_path,
+):
+    """parsedmarc adds nested fields like ``policies.failure_details.*`` to
+    the live mapping only when a doc with that data arrives. The template
+    NDJSON ships those fields baked into ``attributes.fields`` because the
+    SMTP TLS visualizations reference them. If refresh just overwrites with
+    the live response, tenants without failure data lose those fields and
+    the dashboard renders "Could not locate that index-pattern-field"
+    instead of "no data". The fix is a union: live wins on conflict, but
+    template fields absent from live are preserved.
+    """
+    template_fields = [
+        {"name": "org_name", "type": "string"},
+        {"name": "policies.failure_details.failed_session_count", "type": "number"},
+        {"name": "policies.failure_details.result_type", "type": "string"},
+    ]
+    lines = [
+        json.dumps(
+            {
+                "type": "index-pattern",
+                "id": "smtp-id",
+                "attributes": {
+                    "title": "smtp_tls*",
+                    "fields": json.dumps(template_fields),
+                },
+                "references": [],
+            }
+        ),
+    ]
+    svc = _make_template(tmp_path, lines)
+
+    find_response = MagicMock()
+    find_response.json.return_value = {
+        "saved_objects": [
+            {"id": "smtp-id", "attributes": {"title": "acme_corp_smtp_tls*"}},
+        ]
+    }
+    find_response.raise_for_status = MagicMock()
+
+    # Live mapping has only org_name (no failure_details — no failure docs
+    # have arrived yet).
+    fields_response = MagicMock()
+    fields_response.json.return_value = {
+        "fields": [{"name": "org_name", "type": "string"}]
+    }
+    fields_response.raise_for_status = MagicMock()
+
+    put_response = MagicMock()
+    put_response.raise_for_status = MagicMock()
+
+    with patch("dmarc_msp.services.dashboards.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, *args, **kwargs):
+            if "/_find" in url:
+                return find_response
+            return fields_response
+
+        mock_client.get.side_effect = _get
+        mock_client.put.return_value = put_response
+        mock_client_cls.return_value = mock_client
+
+        refreshed = svc.refresh_index_pattern_fields("acme_tenant")
+
+    assert refreshed == 1
+    put_call = mock_client.put.call_args_list[0]
+    written = json.loads(put_call.kwargs["json"]["attributes"]["fields"])
+    written_names = {f["name"] for f in written}
+    assert "org_name" in written_names
+    assert "policies.failure_details.failed_session_count" in written_names
+    assert "policies.failure_details.result_type" in written_names
+
+
+def test_refresh_index_pattern_fields_live_wins_on_conflict(tmp_path):
+    """When a field appears in both live and template, the live entry
+    must win. parsedmarc may have changed the field's type (e.g.,
+    string → keyword) and the template's stale entry shouldn't override
+    the current schema."""
+    template_fields = [
+        {"name": "source_ip_address", "type": "string", "stale": True},
+    ]
+    lines = [
+        json.dumps(
+            {
+                "type": "index-pattern",
+                "id": "agg-id",
+                "attributes": {
+                    "title": "dmarc_aggregate*",
+                    "fields": json.dumps(template_fields),
+                },
+                "references": [],
+            }
+        ),
+    ]
+    svc = _make_template(tmp_path, lines)
+
+    find_response = MagicMock()
+    find_response.json.return_value = {
+        "saved_objects": [
+            {"id": "agg-id", "attributes": {"title": "acme_corp_dmarc_aggregate*"}},
+        ]
+    }
+    find_response.raise_for_status = MagicMock()
+
+    fields_response = MagicMock()
+    fields_response.json.return_value = {
+        "fields": [{"name": "source_ip_address", "type": "ip"}]
+    }
+    fields_response.raise_for_status = MagicMock()
+
+    put_response = MagicMock()
+    put_response.raise_for_status = MagicMock()
+
+    with patch("dmarc_msp.services.dashboards.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, *args, **kwargs):
+            if "/_find" in url:
+                return find_response
+            return fields_response
+
+        mock_client.get.side_effect = _get
+        mock_client.put.return_value = put_response
+        mock_client_cls.return_value = mock_client
+
+        svc.refresh_index_pattern_fields("acme_tenant")
+
+    written = json.loads(
+        mock_client.put.call_args_list[0].kwargs["json"]["attributes"]["fields"]
+    )
+    assert len(written) == 1
+    assert written[0]["name"] == "source_ip_address"
+    assert written[0]["type"] == "ip"
+    assert "stale" not in written[0]
+
+
 def test_delete_orphaned_visualizations_default_targets_match_pr_728():
     """The default ``ORPHANED_VISUALIZATIONS`` list must include the two
     visualizations dropped by upstream parsedmarc PR #728, since the whole


### PR DESCRIPTION
## Summary

`refresh_index_pattern_fields` (and the auto-refresh that runs at the end of every dashboard import) was overwriting each tenant's cached `attributes.fields` with whatever `_fields_for_wildcard` returned from the live mapping. parsedmarc adds nested fields like `policies.failure_details.*` to the OpenSearch mapping only when an actual TLSRPT report contains failure details, so a tenant with no failure data has a live mapping that's a strict subset of the NDJSON's baked-in field list. The refresh stripped those fields, and after merging #18 the new "Failure details" SMTP TLS visualization rendered:

> Could not locate that index-pattern-field (id: policies.failure_details.failed_session_count)

instead of an empty data state.

## Fix

Refresh now unions the live `_fields_for_wildcard` response with the template's baked-in `attributes.fields`, with **live winning on conflict** (so live-mapping schema changes still take effect, e.g. parsedmarc renames a field). Template fields absent from live are preserved.

A new `_load_template_fields_by_id()` helper reads the bundled NDJSON once per refresh and indexes the field lists by saved-object ID so each tenant's index-pattern can be merged against its own template entry.

## Recovery

To repair tenants that already lost their failure_details fields (anyone who ran `dashboard import-all --replace` and/or `migrate refresh-index-fields` after merging #18):

```bash
dmarcmsp dashboard import-all --replace
# or, without re-importing dashboards:
dmarcmsp migrate refresh-index-fields
```

The next refresh repopulates the missing nested fields from the bundled NDJSON.

## Test plan
- [x] `pytest` — full suite, 286 passing (2 new tests).
- [x] `ruff check` / `ruff format --check` clean on touched files.
- [ ] On a staging tenant with no failure_details data, run `dashboard import-all --replace` and confirm the SMTP TLS dashboard's "Failure details" panel renders empty rather than the field-not-found error.
- [ ] On a tenant that *does* have failure_details data, confirm the panel still aggregates correctly (live wins on conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)